### PR TITLE
Dashboard: mostrar clientes atendidos en el mes

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -299,6 +299,13 @@
         </div>
         <div class="hero-stat">
           <div class="hero-stat-icon">
+            <i class="fas fa-user-check"></i>
+          </div>
+          <div class="hero-stat-value" id="stat-attended-clients">0</div>
+          <div class="hero-stat-label">Clientes atendidos este mes</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-icon">
             <i class="fas fa-trophy"></i>
           </div>
           <div class="hero-stat-value" id="stat-return-rate">0%</div>
@@ -12013,12 +12020,15 @@
         const metricsJson = await metricsRes.json();
 
         if (metricsJson.success && metricsJson.data) {
-          const { total, activeClients, stampsThisMonth, redeemsThisMonth, returnRate } = metricsJson.data;
+          const { total, activeClients, stampsThisMonth, redeemsThisMonth, returnRate, attendedClients } = metricsJson.data;
 
           document.getElementById('stat-total-clients').textContent = activeClients || total;
           document.getElementById('stat-stamps-month').textContent = stampsThisMonth;
           document.getElementById('stat-redeems-month').textContent = redeemsThisMonth;
           document.getElementById('stat-return-rate').textContent = returnRate + '%';
+
+          const attendedEl = document.getElementById('stat-attended-clients');
+          if (attendedEl) attendedEl.textContent = attendedClients ?? 0;
         }
 
         // 2. Cargar TODAS las tarjetas para top clientes y cumpleaños

--- a/server.js
+++ b/server.js
@@ -495,12 +495,34 @@ async function fsMetricsMonth() {
   });
   const returnRate = total > 0 ? Math.round((returningClients / total) * 100) : 0;
 
+  // Clientes atendidos este mes: citas completadas en el mes actual,
+  // contando clientes únicos (por teléfono, o por nombre si no hay teléfono).
+  const [yyyy, mm] = todayMexicoStr().split('-');
+  const monthStart = `${yyyy}-${mm}-01`;
+  const monthEnd = `${yyyy}-${mm}-31`;
+
+  const apptSnap = await firestore
+    .collection('appointments')
+    .where('date', '>=', monthStart)
+    .where('date', '<=', monthEnd)
+    .get();
+
+  const attendedKeys = new Set();
+  apptSnap.forEach((doc) => {
+    const a = doc.data();
+    if (a.status !== 'completed') return;
+    const key = (a.clientPhone || '').trim() || (a.clientName || '').trim().toLowerCase();
+    if (key) attendedKeys.add(key);
+  });
+  const attendedClients = attendedKeys.size;
+
   return {
     total,
     activeClients,
     stampsThisMonth: counts.stamp,
     redeemsThisMonth: counts.redeem,
-    returnRate
+    returnRate,
+    attendedClients,
   };
 }
 


### PR DESCRIPTION
## Resumen

Agrega al Dashboard del admin una nueva tarjeta que muestra **cuántos clientes se atendieron en el mes actual**.

## Cambios

**Backend** (`server.js` → `fsMetricsMonth()`)
- Cuenta los **clientes únicos** con citas en estado `completed` durante el mes en curso (zona horaria de México).
- Se identifican por teléfono (o por nombre si no hay teléfono) para no contar dos veces al mismo cliente si vino varias veces.
- Se expone como `attendedClients` en el endpoint `GET /api/admin/metrics-month`.

**Frontend** (`public/admin.html`)
- Nueva tarjeta **"Clientes atendidos este mes"** en la sección de hero stats del dashboard.
- `loadDashboardStats()` rellena el valor automáticamente.

## Notas
- "Atendido" se define como cita `completed`, el mismo criterio que ya usa el panel de "Hoy" para los ingresos, así que es consistente.
- La métrica depende de que las citas se marquen como completadas al atender al cliente.

https://claude.ai/code/session_01UCFVs2JcFdUbq7uk8Y4eqp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCFVs2JcFdUbq7uk8Y4eqp)_