### PR TITLE
Fix: contar clientes atendidos desde Prisma, no Firestore

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -299,6 +299,13 @@
         </div>
         <div class="hero-stat">
           <div class="hero-stat-icon">
+            <i class="fas fa-user-check"></i>
+          </div>
+          <div class="hero-stat-value" id="stat-attended-clients">0</div>
+          <div class="hero-stat-label">Clientes atendidos este mes</div>
+        </div>
+        <div class="hero-stat">
+          <div class="hero-stat-icon">
             <i class="fas fa-trophy"></i>
           </div>
           <div class="hero-stat-value" id="stat-return-rate">0%</div>
@@ -12013,12 +12020,15 @@
         const metricsJson = await metricsRes.json();
 
         if (metricsJson.success && metricsJson.data) {
-          const { total, activeClients, stampsThisMonth, redeemsThisMonth, returnRate } = metricsJson.data;
+          const { total, activeClients, stampsThisMonth, redeemsThisMonth, returnRate, attendedClients } = metricsJson.data;
 
           document.getElementById('stat-total-clients').textContent = activeClients || total;
           document.getElementById('stat-stamps-month').textContent = stampsThisMonth;
           document.getElementById('stat-redeems-month').textContent = redeemsThisMonth;
           document.getElementById('stat-return-rate').textContent = returnRate + '%';
+
+          const attendedEl = document.getElementById('stat-attended-clients');
+          if (attendedEl) attendedEl.textContent = attendedClients ?? 0;
         }
 
         // 2. Cargar TODAS las tarjetas para top clientes y cumpleaños

--- a/server.js
+++ b/server.js
@@ -497,23 +497,24 @@ async function fsMetricsMonth() {
 
   // Clientes atendidos este mes: citas completadas en el mes actual,
   // contando clientes únicos (por teléfono, o por nombre si no hay teléfono).
+  // Las citas viven en Prisma (mismo origen que sources-this-month).
   const [yyyy, mm] = todayMexicoStr().split('-');
   const monthStart = `${yyyy}-${mm}-01`;
   const monthEnd = `${yyyy}-${mm}-31`;
 
-  const apptSnap = await firestore
-    .collection('appointments')
-    .where('date', '>=', monthStart)
-    .where('date', '<=', monthEnd)
-    .get();
+  const completedAppts = await prisma.appointment.findMany({
+    where: {
+      date: { gte: monthStart, lte: monthEnd },
+      status: 'completed',
+    },
+    select: { clientPhone: true, clientName: true },
+  });
 
   const attendedKeys = new Set();
-  apptSnap.forEach((doc) => {
-    const a = doc.data();
-    if (a.status !== 'completed') return;
+  for (const a of completedAppts) {
     const key = (a.clientPhone || '').trim() || (a.clientName || '').trim().toLowerCase();
     if (key) attendedKeys.add(key);
-  });
+  }
   const attendedClients = attendedKeys.size;
 
   return {

--- a/server.js
+++ b/server.js
@@ -495,12 +495,34 @@ async function fsMetricsMonth() {
   });
   const returnRate = total > 0 ? Math.round((returningClients / total) * 100) : 0;
 
+  // Clientes atendidos este mes: citas completadas en el mes actual,
+  // contando clientes únicos (por teléfono, o por nombre si no hay teléfono).
+  const [yyyy, mm] = todayMexicoStr().split('-');
+  const monthStart = `${yyyy}-${mm}-01`;
+  const monthEnd = `${yyyy}-${mm}-31`;
+
+  const apptSnap = await firestore
+    .collection('appointments')
+    .where('date', '>=', monthStart)
+    .where('date', '<=', monthEnd)
+    .get();
+
+  const attendedKeys = new Set();
+  apptSnap.forEach((doc) => {
+    const a = doc.data();
+    if (a.status !== 'completed') return;
+    const key = (a.clientPhone || '').trim() || (a.clientName || '').trim().toLowerCase();
+    if (key) attendedKeys.add(key);
+  });
+  const attendedClients = attendedKeys.size;
+
   return {
     total,
     activeClients,
     stampsThisMonth: counts.stamp,
     redeemsThisMonth: counts.redeem,
-    returnRate
+    returnRate,
+    attendedClients,
   };
 }
 


### PR DESCRIPTION
## Problema

La tarjeta "Clientes atendidos este mes" mostraba siempre **0**.

## Causa

Las citas completadas (`status: 'completed'`) se almacenan en **Prisma (PostgreSQL)** — el endpoint de pago usa `AppointmentsRepo.complete()`, igual que `sources-this-month`. La implementación inicial leía Firestore, donde no viven las citas completadas, por lo que el conteo siempre era 0.

## Solución

`fsMetricsMonth()` ahora cuenta clientes únicos con citas `completed` del mes actual usando `prisma.appointment.findMany`, consistente con el resto de métricas de citas.

https://claude.ai/code/session_01UCFVs2JcFdUbq7uk8Y4eqp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCFVs2JcFdUbq7uk8Y4eqp)_